### PR TITLE
Replace ifconfig to ip command

### DIFF
--- a/deploy/faas_lab_setup.sh
+++ b/deploy/faas_lab_setup.sh
@@ -22,7 +22,7 @@ IFS=',' read -r -a NODES <<< "$NODELIST"
 ./weavenet_setup.sh
 
 #IP=$(ifconfig eno49 | grep "inet addr:" | awk '{print $2}' | cut -c6-):6443
-IP=$(ifconfig $(route | grep '^default' | grep -o '[^ ]*$') | grep "inet addr:" | awk '{print $2}' | cut -c6-):6443
+IP=$(ip addr sh dev $(ip ro sh | grep default | awk '{print $5}') scope global | grep inet | awk '{split($2,addresses,"/"); print addresses[1]}'):6443
 TOKEN=$(kubeadm token list | tail -n 1 | cut -d ' ' -f 1)
 HASH=sha256:$(openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //')
 
@@ -38,7 +38,7 @@ done
 wait_for_worker
 
 #IP=$(ifconfig eno49 | grep "inet addr:" | awk '{print $2}' | cut -c6-):5000
-IP=$(ifconfig $(route | grep '^default' | grep -o '[^ ]*$') | grep "inet addr:" | awk '{print $2}' | cut -c6-):5000
+IP=$(ip addr sh dev $(ip ro sh | grep default | awk '{print $5}') scope global | grep inet | awk '{split($2,addresses,"/"); print addresses[1]}'):5000
 ./docker_registry_setup.sh $IP
 
 for i in "${NODES[@]}"

--- a/utils/create_function.sh
+++ b/utils/create_function.sh
@@ -1,7 +1,7 @@
 mkdir -p functions
 cd functions
 faas-cli new --lang python $1
-IP=$(ifconfig $(route | grep '^default' | grep -o '[^ ]*$') | grep "inet addr:" | awk '{print $2}' | cut -c6-)
+IP=$(ip addr sh dev $(ip ro sh | grep default | awk '{print $5}') scope global | grep inet | awk '{split($2,addresses,"/"); print addresses[1]}')
 sed -i '$ d' $1.yml && echo "    image: $IP:5000/$1" >> $1.yml
 
 printf 'def handle(req):\n    return req + " " + str("%s")\n' $2 > ./$1/handler.py

--- a/utils/get_dashboard_login_token.sh
+++ b/utils/get_dashboard_login_token.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DASH_ADDR=$(ifconfig $(route | grep '^default' | grep -o '[^ ]*$') | grep "inet addr:" | awk '{print $2}' | cut -c6-):$(kubectl get services -n kube-system | grep kubernetes-dashboard | awk '{ print $5 }' | cut -d ':' -f 2 | cut -d '/' -f 1)
+DASH_ADDR=$(ip addr sh dev $(ip ro sh | grep default | awk '{print $5}') scope global | grep inet | awk '{split($2,addresses,"/"); print addresses[1]}'):$(kubectl get services -n kube-system | grep kubernetes-dashboard | awk '{ print $5 }' | cut -d ':' -f 2 | cut -d '/' -f 1)
 
 echo "Kubernetes dashboard is running on https://$DASH_ADDR"
 echo "Token:"


### PR DESCRIPTION
Change ifconfig to ip, because it's deprecated.
Later, e.g. in Ubuntu 18.04, ifconfig output is changed as well.